### PR TITLE
Исправление ошибки с закрытием сервиса в тесте distibute

### DIFF
--- a/src/test/java/ok/dht/ServiceTest.java
+++ b/src/test/java/ok/dht/ServiceTest.java
@@ -182,8 +182,8 @@ public @interface ServiceTest {
                 ExtensionContext.Store.CloseableResource res = () -> {
                     if (closeAfterExecution) {
                         service.stop().get(10, TimeUnit.MINUTES);
-                        FileUtils.delete(workingDir);
                     }
+                    FileUtils.delete(workingDir);
                 };
 
                 context.getStore(NAMESPACE).put(ID.incrementAndGet() + "", res);

--- a/src/test/java/ok/dht/ShardingTest.java
+++ b/src/test/java/ok/dht/ShardingTest.java
@@ -168,7 +168,7 @@ class ShardingTest extends TestBase {
         assertEquals(HttpURLConnection.HTTP_NOT_FOUND, serviceInfos.get(1).get(key).statusCode());
     }
 
-    @ServiceTest(stage = 3, clusterSize = 2)
+    @ServiceTest(stage = 3, clusterSize = 2, closeAfterExecution = false)
     void distribute(List<ServiceInfo> serviceInfos) throws Exception {
         final String key = randomId();
         final byte[] value = randomValue();


### PR DESCRIPTION
Сейчас в тесте на 3 этап я заметил странное поведение. В процессе самого теста вызывается метод stop() на каждом из наших шардов, но затем общий код тестов после его завершения делает это еще раз. Получается мы на шарде вызываем дважды метод stop.

Но на реализации бонусного теста из первого этапа мы добавили код, который закрывает сессии на селекторе. Однако попытка итерации по селектору когда он уже закрыт кидает ClosedSelectorException и тест падает несмотря на успешное завершение.

Если это не задуманное поведение предлагаю вот такой фикс.
