### PR TITLE
[NOT FOR MERGE] Add starvation test for drozdov service implementation

### DIFF
--- a/src/main/java/ok/dht/test/pashchenko/MyServer.java
+++ b/src/main/java/ok/dht/test/pashchenko/MyServer.java
@@ -78,6 +78,12 @@ public class MyServer extends HttpServer {
         Node node = getNodeForKey(id);
 
         int tasks = node.tasksCount.incrementAndGet();
+        try {
+            Thread.sleep(tasks * 100L);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+
         if (tasks > Node.MAX_TASKS_ALLOWED) {
             node.tasksCount.decrementAndGet();
             session.sendResponse(new Response(Response.SERVICE_UNAVAILABLE, Response.EMPTY));
@@ -221,9 +227,9 @@ public class MyServer extends HttpServer {
         }
     }
 
-    static class Node {
+    public static class Node {
         static final int MAX_TASKS_ALLOWED = 128;
-        static final int MAX_WORKERS_ALLOWED = 3;
+        public static final int MAX_WORKERS_ALLOWED = 1;
 
         final String url;
         final ConcurrentLinkedQueue<Runnable> tasks = new ConcurrentLinkedQueue<>();


### PR DESCRIPTION
Нашел в lock-free реализации референсного сервиса баги.

## Баг №1

Конфигурация:
MAX_WORKERS_ALLOWED = 1
MAX_TASKS_ALLOWED = 10

Пошаговое описание:
1. Параллельно запускаем 2 запроса. Обозначим треды селектора для них, как t1 и t2
2. Оба запроса делают tasksCount.incrementAndGet().
t1.tasks = 1
t2.tasks = 2
3. t1 выполняет все инструкции до конца функции handleRequest()
4. Воркер выполняет запрос из селектора t1, запускает еще итерацию воркера
5. Воркер завершает работу, так как в очереди нет задач
6. t2 просыпается, создает задачу в очереди
7. t2.tasks > MAX_WORKERS_ALLOWED, значит, воркер не создается
8. Если запрросов на сервер больше не поступит, таска из t2 никогда не обработается

Тест:
Написал тест, который не проходит для референсной реализации. Мерджить его в таком виде не надо, он сильно опирается на референсную реализацию (особенно на вставленный Thread.sleep())

## Баг №2

Конфигурация:
MAX_WORKERS_ALLOWED = 1
MAX_TASKS_ALLOWED = 10

Пошаговое описание:
1. Делаем 1 запрос.
2. Запрос обрабатывается, создается воркер, он отвечает на запрос
3. Замораживаем тред воркера перед `node.tasks.poll()` (заметим, что сейчас очередь пуста)
4. Делаем еще 1 запрос
5. `node.tasksCount == 0`, поэтому задача добавляется в очередь и создается еще один воркер (++node.tasksCount <= MAX_WORKERS_ALLOWED выполняется)
6. Замораживаем 2-го воркера перед `node.tasks.poll()` (в очереди 1 задача)
7. Делаем еще 1 запрос.
8. `node.tasksCount == 1`, поэтому задача добавляется в очередь, но новый воркер не создается
9. Размораживаем воркеров
10. Для каждого воркера есть задача, то есть теперь параллельно над задачами работают 2 воркера - баг
11. Так можно продолжать добавлять воркеров и забить весь тред пул ими